### PR TITLE
Added Span extension methods.

### DIFF
--- a/GoeaLabs.Bedrock.Tests/Extensions/SpansExTests.cs
+++ b/GoeaLabs.Bedrock.Tests/Extensions/SpansExTests.cs
@@ -1,0 +1,86 @@
+﻿using GoeaLabs.Bedrock.Extensions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoeaLabs.Bedrock.Tests.Extensions
+{
+    [TestClass]
+    public class SpansExTests
+    {
+
+        [TestMethod]
+        [DataRow(new uint[] { 0xFFFFFFFF }, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF })]
+        [DataRow(new uint[] { 0xFFFFFFFF, 0x0000FFFF }, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF })]
+        public void Split_uints_to_bytes_behaves_correctly(uint[] data, byte[] okay)
+        {
+            Span<uint> dataS = data;
+            Span<byte> okayS = okay;
+
+            Span<byte> testS = stackalloc byte[dataS.Length * sizeof(uint)];
+            dataS.Split(testS);
+
+            Assert.IsTrue(testS.ToArray().IsEqual(okay));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Split_uints_to_bytes_throws_ArgumentException_if_input_too_large()
+        {
+            var max = int.MaxValue / sizeof(uint);
+            var arr = new uint[++max];
+
+            Span<uint> uints = arr;
+            Span<byte> bytes = stackalloc byte[1];
+
+            uints.Split(bytes);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Split_uints_to_bytes_throws_ArgumentException_if_output_too_small()
+        {
+            Span<uint> uints = stackalloc uint[1];
+            Span<byte> bytes = stackalloc byte[1];
+
+            uints.Split(bytes);
+        }
+
+        [TestMethod]
+        [DataRow(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, new uint[] { 0xFFFFFFFF })]
+        [DataRow(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF }, new uint[] { 0xFFFFFFFF, 0x0000FFFF })]
+        public void Merge_bytes_to_uints_behaves_correctly(byte[] data, uint[] okay)
+        {
+            Span<byte> dataS = data;
+            Span<uint> okayS = okay;
+
+            Span<uint> testS = stackalloc uint[dataS.Length / sizeof(uint)];
+            dataS.Merge(testS);
+
+            Assert.IsTrue(testS.ToArray().IsEqual(okay));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Merge_bytes_to_uints_throws_ArgumentException_if_input_not_multiple_of_sizeof_uint()
+        {
+            Span<byte> bytes = stackalloc byte[7];
+            Span<uint> uints = stackalloc uint[2];
+
+            bytes.Merge(uints);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Merge_bytes_to_uints_throws_ArgumentException_if_output_too_small()
+        {
+            Span<byte> bytes = stackalloc byte[8];
+            Span<uint> uints = stackalloc uint[1];
+
+            bytes.Merge(uints);
+        }
+    }
+}

--- a/GoeaLabs.Bedrock/Extensions/SpansEx.cs
+++ b/GoeaLabs.Bedrock/Extensions/SpansEx.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoeaLabs.Bedrock.Extensions
+{
+    /// <summary>
+    /// Extensions for integer spans.
+    /// </summary>
+    public static class SpansEx
+    {
+
+        /// <summary>
+        /// Writes the content of the Span to a Span of <see cref="byte"/>(s);
+        /// </summary>
+        /// <remarks>
+        /// Throws <see cref="ArgumentException"/>:
+        /// <list type="bullet">
+        /// <item>If the length of <paramref name="self"/> is greater than <c>int.MaxValue / sizeof(uint)</c></item>
+        /// <item>If the length of <paramref name="that"/> is less than <c>self.Length * sizeof(uint)</c>.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="self">The span to split.</param>
+        /// <param name="that">The span to write to.</param>
+        public static void Split(this Span<uint> self, Span<byte> that)
+        {
+            var selfMax = int.MaxValue / sizeof(uint);
+
+            if (self.Length > selfMax)
+                throw new ArgumentException($"Length must be maximum {selfMax}", nameof(self));
+
+            var thatMin = self.Length * sizeof(uint);
+
+            if (that.Length < thatMin)
+                throw new ArgumentException($"Length must be minimum {thatMin}", nameof(that));
+
+            for (int i = 0; i < self.Length; i++)
+            {
+                self[i].Halve(out ushort n16a, out ushort n16b);
+                
+                n16a.Halve(out byte n8a, out byte n8b);
+                n16b.Halve(out byte n8c, out byte n8d);
+
+                var pos = i * sizeof(uint);
+
+                that[pos++] = n8a;
+                that[pos++] = n8b;
+                that[pos++] = n8c;
+                that[pos++] = n8d;
+            }
+        }
+
+        /// <summary>
+        /// Writes the content of the Span to a Span of <see cref="uint"/>(s);
+        /// </summary>
+        /// <remarks>
+        /// Throws <see cref="ArgumentException"/>:
+        /// <list type="bullet">
+        /// <item>If the length of <paramref name="self"/> is not equal to or multiple of <c>sizeof(uint)</c>.</item>
+        /// <item>If the length of <paramref name="that"/> is less than <c>self.Length / sizeof(uint)</c>.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="self">The span to split.</param>
+        /// <param name="that">The span to write to.</param>
+        public static void Merge(this Span<byte> self, Span<uint> that)
+        {
+            if (self.Length % sizeof(uint) > 0)
+                throw new ArgumentException($"Length must be a multiple of {sizeof(uint)}", nameof(self));
+
+            var thatMin = self.Length / sizeof(uint);
+
+            if (that.Length < thatMin)
+                throw new ArgumentException($"Length must be minimum {thatMin}", nameof(that));
+
+            for (int i = 0; i < that.Length; i++)
+            {
+                var pos = i * sizeof(uint);
+
+                var n16a = self[pos].Merge(self[++pos]);
+                var n16b = self[++pos].Merge(self[++pos]);
+
+                that[i] = n16a.Merge(n16b);               
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds 2 extension methods allowing to split a `Span<uint>` to `Span<byte>` and merge a `Span<byte>` to `Span<uint>` in an endianness agnostic way.