### PR TITLE
Added Span extensions allowing merges from uint to ulong and UInt128.

### DIFF
--- a/GoeaLabs.Bedrock.Tests/AssemblyInfo.cs
+++ b/GoeaLabs.Bedrock.Tests/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+/*
+   Copyright 2022, GoeaLabs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+
+[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]

--- a/GoeaLabs.Bedrock.Tests/Extensions/ArraysExTests.cs
+++ b/GoeaLabs.Bedrock.Tests/Extensions/ArraysExTests.cs
@@ -14,10 +14,13 @@
    limitations under the License.
  */
 
+
 using GoeaLabs.Bedrock.Extensions;
+
 
 namespace GoeaLabs.Bedrock.Tests.Extensions
 {
+
     [TestClass]
     public class ArraysExTests
     {

--- a/GoeaLabs.Bedrock.Tests/Extensions/IntegersExTests.cs
+++ b/GoeaLabs.Bedrock.Tests/Extensions/IntegersExTests.cs
@@ -14,10 +14,13 @@
    limitations under the License.
  */
 
+
 using GoeaLabs.Bedrock.Extensions;
+
 
 namespace GoeaLabs.Bedrock.Tests.Extensions
 {
+
     [TestClass]
     public class IntegersExTests
     {

--- a/GoeaLabs.Bedrock.Tests/Extensions/IntegersTests.cs
+++ b/GoeaLabs.Bedrock.Tests/Extensions/IntegersTests.cs
@@ -17,8 +17,10 @@
 
 using System.Numerics;
 
+
 namespace GoeaLabs.Bedrock.Tests.Extensions
 {
+
     [TestClass]
     public class IntegersTests
     {

--- a/GoeaLabs.Bedrock.Tests/GoeaLabs.Bedrock.Tests.csproj
+++ b/GoeaLabs.Bedrock.Tests/GoeaLabs.Bedrock.Tests.csproj
@@ -9,10 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ void Merge(this Span<byte>, Span<uint>);
 ```
 
 ```csharp
+void Merge(this Span<uint>, Span<ulong>);
+```
+
+```csharp
+#if NET7_0_OR_GREATER
+void Merge(this Span<uint>, Span<UInt128>);
+#endif
+```
+
+```csharp
 void XOR(this Span<byte>, Span<byte>);
 ```
 


### PR DESCRIPTION
This PR adds two ```Span``` extension methods:

- For **NET6+** targets:
```csharp
static void Merge(this Span<uint> self, Span<ulong> that);
```  
- For **NET7+** targets:
```csharp
static void Merge(this Span<uint> self, Span<UInt128> that);
``` 